### PR TITLE
README cleanups with install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+rested
+======
+
+OS X Install*
+============
+Installing QT and PyQT is a pain on OS X. I am not an expert in either
+one. The correct steps are left as an exercise to the reader.
+       *DO NOT CONTACT ME ABOUT PROBLEMS INSTALLING QT/PYQT.*
+
+Requirements:
+1. Qt 4 and PyQt
+```bash
+# cmake is needed for PySide
+brew install cmake pyqt
+```
+2. PySide
+Download and run the binary installer from [PySide Binaries for Mac OS X](http://qt-project.org/wiki/PySide_Binaries_MacOSX).
+The one labelled [PySide 1.1.0 for Python 2.7](http://pyside.markus-ullmann.de/pyside-1.1.0-qt47-py27apple.pkg) worked well for me
+on OS X 10.8 with Python 2.7.
+3. Rested code + libs
+The PyQt and PySide libraries will be installed in the global python context
+and will not be present in a virtualenv unless you specifically ask them to
+be.
+```bash
+# inherit the system python packages to get PyQt and PySide in the virtualenv
+mkvirtualenv --system-site-packages rested
+
+# grab the source and go into dir
+git clone https://github.com/carschar/rested.git
+cd rested
+
+# install dependencies
+pip install -r requirements.txt
+```
+
+Running It
+==========
+```python rested/app.py```

--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
 rested
 ======
 
-OS X Install*
-============
+#OS X Install*
+
 Installing QT and PyQT is a pain on OS X. I am not an expert in either
 one. The correct steps are left as an exercise to the reader.
        *DO NOT CONTACT ME ABOUT PROBLEMS INSTALLING QT/PYQT.*
 
-Requirements:
+##Requirements:
 1. Qt 4 and PyQt
-```bash
-# cmake is needed for PySide
-brew install cmake pyqt
-```
+
+```brew install cmake pyqt```
+
 2. PySide
+
 Download and run the binary installer from [PySide Binaries for Mac OS X](http://qt-project.org/wiki/PySide_Binaries_MacOSX).
 The one labelled [PySide 1.1.0 for Python 2.7](http://pyside.markus-ullmann.de/pyside-1.1.0-qt47-py27apple.pkg) worked well for me
 on OS X 10.8 with Python 2.7.
+
 3. Rested code + libs
+
 The PyQt and PySide libraries will be installed in the global python context
 and will not be present in a virtualenv unless you specifically ask them to
 be.
+
 ```bash
 # inherit the system python packages to get PyQt and PySide in the virtualenv
 mkvirtualenv --system-site-packages rested
@@ -33,6 +36,6 @@ cd rested
 pip install -r requirements.txt
 ```
 
-Running It
-==========
+##Running It
+
 ```python rested/app.py```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ rested
 Rested is a reStructuredText editor written in Python with the QT framework. It is sole copyright of [Enthought](https://enthought.com/). 
 
 Resources:
-* Blog post about features added during Google Summer of Code 2010: [](http://blog.enthought.com/enthought-tool-suite/a-renewed-restructured-text-editor/)
-* Original code in [enthought/rested]() repository.
+* Blog post about features added in 2010: [A Renewed ReStructuredText Editor!](http://blog.enthought.com/enthought-tool-suite/a-renewed-restructured-text-editor/)
+* Original code resides in [enthought/rested](https://github.com/enthought/rested) repository.
 
 # Debian/Ubuntu Install
 Instructions from [Issue 5 in enthought repo](https://github.com/enthought/rested/issues/5)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ rested
 ======
 Rested is a reStructuredText editor written in Python with the QT framework. It is sole copyright of [Enthought](https://enthought.com/). 
 
-Blog post about features added during Google Summer of Code 2010: [](http://blog.enthought.com/enthought-tool-suite/a-renewed-restructured-text-editor/)
-Original code in [enthought/rested]() repository.
+Resources:
+* Blog post about features added during Google Summer of Code 2010: [](http://blog.enthought.com/enthought-tool-suite/a-renewed-restructured-text-editor/)
+* Original code in [enthought/rested]() repository.
 
 # Debian/Ubuntu Install
 Instructions from [Issue 5 in enthought repo](https://github.com/enthought/rested/issues/5)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 rested
 ======
+Rested is a reStructuredText editor written in Python with the QT framework. It is sole copyright of [Enthought](https://enthought.com/). 
+
+Blog post about features added during Google Summer of Code 2010: [](http://blog.enthought.com/enthought-tool-suite/a-renewed-restructured-text-editor/)
+Original code in [enthought/rested]() repository.
+
+# Debian/Ubuntu Install
+Instructions from [Issue 5 in enthought repo](https://github.com/enthought/rested/issues/5)
+```bash
+sudo apt-get install build-essential python-pip python-dev
+sudo pip install numpy configobj pygments docutils sphinx rst2pdf
+
+# grab the source
+git clone https://github.com/enthought/rested
+cd rested
+
+sudo python setup.py install
+```
+
 
 #OS X Install*
 
@@ -22,20 +40,24 @@ on OS X 10.8 with Python 2.7.
 
 The PyQt and PySide libraries will be installed in the global python context
 and will not be present in a virtualenv unless you specifically ask them to
-be.
+be. 
 
 ```bash
-# inherit the system python packages to get PyQt and PySide in the virtualenv
-mkvirtualenv --system-site-packages rested
-
-# grab the source and go into dir
+# grab the source
 git clone https://github.com/carschar/rested.git
 cd rested
 
-# install dependencies
-pip install -r requirements.txt
+python setup.py install
 ```
 
-##Running It
 
+# Running It (applies to Linux/OS X)
+Create a small helper script to execute the app:
+```
+#!/bin/bash
+# Run Enthought's rested ReStructuredText editor.
+python -c "from rested import app; app.main()" "$@" 2&>1 &
+```
+
+Or you can run it directly from the git repo:
 ```python rested/app.py```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# These are pulled from rested/__init__.py for easier install with pip.
+# Deliberately did not peg versions - don't know the bounds of what will work.
+configobj
+docutils
+pyface
+traits
+traitsui


### PR DESCRIPTION
I documented the OS X install steps, pulled in the debian install steps from Issue 5, and cleaned up the README file. No functional changes.
